### PR TITLE
Fix podspec apostrophe build error

### DIFF
--- a/ios/flutter_qr_bar_scanner.podspec
+++ b/ios/flutter_qr_bar_scanner.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_qr_bar_scanner'
   s.version          = '0.0.1'
-  s.summary          = 'A Plugin for reading/scanning QR & Bar codes using Google's Mobile Vision API'
+  s.summary          = "A Plugin for reading/scanning QR & Bar codes using Google's Mobile Vision API"
   s.description      = <<-DESC
 A Plugin for reading/scanning QR & Bar codes using Google's Mobile Vision API.
                        DESC
@@ -12,10 +12,10 @@ A Plugin for reading/scanning QR & Bar codes using Google's Mobile Vision API.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
+
   s.ios.deployment_target = '8.0'
-  
+
   s.dependency 'GoogleMobileVision/BarcodeDetector'
-  
+
   s.static_framework = true
 end


### PR DESCRIPTION
Building on iOS causes the following error:

```
<app_path>/ios/.symlinks/plugins/flutter_qr_bar_scanner/ios/flutter_qr_bar_scanner.podspec:6:
  syntax error, unexpected tIDENTIFIER, expecting keyword_end
  ...g QR & Bar codes using Google's Mobile Vision API.
```