### PR TITLE
Updated native device orientation dependency to 1.0.0 in order to support flutter version  >= 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  native_device_orientation: ^0.3.0
+  native_device_orientation: ^1.0.0


### PR DESCRIPTION
Updated native device orientation dependency to 1.0.0 in order to support flutter version  >= 2